### PR TITLE
Refactor bitcoin node config layout

### DIFF
--- a/roles/bitcoin/tasks/main.yml
+++ b/roles/bitcoin/tasks/main.yml
@@ -1,7 +1,13 @@
 - name: Ensure config dir exists
   ansible.builtin.file:
-    path: "{{ workdir }}/conf"
+    path: "{{ workdir }}/config"
     state: directory
+
+- name: Ensure per-node config dirs exist
+  ansible.builtin.file:
+    path: "{{ workdir }}/config/node{{ '%02d'|format(item) }}"
+    state: directory
+  loop: "{{ range(1, (node_count | int) + 1) | list }}"
 
 - name: Template docker-compose.yml
   ansible.builtin.template:
@@ -11,7 +17,7 @@
 - name: Render per-node bitcoin.conf files
   ansible.builtin.template:
     src: "bitcoin.conf.j2"
-    dest: "{{ workdir }}/conf/node{{ '%02d'|format(item) }}.conf"
+    dest: "{{ workdir }}/config/node{{ '%02d'|format(item) }}/bitcoin.conf"
   loop: "{{ range(1, node_count + 1) | list }}"
 
 - name: Ensure data dirs exist

--- a/roles/bitcoin/templates/bitcoin.conf.j2
+++ b/roles/bitcoin/templates/bitcoin.conf.j2
@@ -4,3 +4,6 @@ server=1
 maxmempool=500
 rpcallowip=0.0.0.0/0
 rpcbind=0.0.0.0
+rpcuser={{ rpc_user }}
+rpcpassword={{ rpc_pass }}
+


### PR DESCRIPTION
## Summary
- create per-node config directories under `config/nodeXX`
- template bitcoin.conf with rpc credentials

## Testing
- `ansible-playbook -i inventory.ini playbooks/02_deploy.yml --become --ask-become-pass` *(fails: Python interpreter discovery error)*

------
https://chatgpt.com/codex/tasks/task_e_68b849261630832cbe52d4bdb470535e