### PR TITLE
Create wallet automatically in txgen

### DIFF
--- a/files/txgen.py
+++ b/files/txgen.py
@@ -29,6 +29,13 @@ if __name__ == "__main__":
     cred, host = rest.split("@")
     auth = cred
 
+    try:
+        rpc_call(proto + "://" + host, "createwallet", ["faultlab"], auth=auth)
+    except RuntimeError as e:
+        # Ignore wallet already exists errors so the script can be rerun
+        if "already exists" not in str(e):
+            raise
+
     addr = rpc_call(proto + "://" + host, "getnewaddress", auth=auth)
     rpc_call(proto + "://" + host, "generatetoaddress", [101, addr], auth=auth)
 


### PR DESCRIPTION
## Summary
- Ensure txgen creates a wallet before requesting addresses
- Ignore existing wallet errors so the script is rerunnable

## Testing
- `python -m py_compile files/txgen.py`


------
https://chatgpt.com/codex/tasks/task_e_68b840198a60832cb299f8700b69e226