### PR TITLE
Mount only data dirs for bitcoin nodes

### DIFF
--- a/btc-faultlab/docker-compose.yml
+++ b/btc-faultlab/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node01:/bitcoin/.bitcoin
-      - ./conf/node01.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         ports:
       - "28332:28332"   # ZMQ block
@@ -36,7 +35,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node02:/bitcoin/.bitcoin
-      - ./conf/node02.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node03:
     image: ruimarinho/bitcoin-core:27.0
@@ -53,7 +51,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node03:/bitcoin/.bitcoin
-      - ./conf/node03.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node04:
     image: ruimarinho/bitcoin-core:27.0
@@ -70,7 +67,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node04:/bitcoin/.bitcoin
-      - ./conf/node04.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node05:
     image: ruimarinho/bitcoin-core:27.0
@@ -87,7 +83,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node05:/bitcoin/.bitcoin
-      - ./conf/node05.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node06:
     image: ruimarinho/bitcoin-core:27.0
@@ -104,7 +99,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node06:/bitcoin/.bitcoin
-      - ./conf/node06.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node07:
     image: ruimarinho/bitcoin-core:27.0
@@ -121,7 +115,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node07:/bitcoin/.bitcoin
-      - ./conf/node07.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
         node08:
     image: ruimarinho/bitcoin-core:27.0
@@ -138,7 +131,6 @@ services:
       - "-conf=/bitcoin/.bitcoin/bitcoin.conf"
     volumes:
       - ./data/node08:/bitcoin/.bitcoin
-      - ./conf/node08.conf:/bitcoin/.bitcoin/bitcoin.conf:ro
     networks: [ btcnet ]
       
   txgen:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node01/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node01:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node02:
@@ -23,7 +22,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node02/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node02:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node03:
@@ -35,7 +33,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node03/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node03:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node04:
@@ -47,7 +44,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node04/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node04:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node05:
@@ -59,7 +55,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node05/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node05:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node06:
@@ -71,7 +66,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node06/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node06:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node07:
@@ -83,7 +77,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node07/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node07:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
   node08:
@@ -95,7 +88,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "/home/vincent/btc-faultlab/config/node08/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "/home/vincent/btc-faultlab/data/node08:/home/bitcoin/.bitcoin"
     networks: [ "btcnet" ]
 

--- a/roles/bitcoin/tasks/main.yml
+++ b/roles/bitcoin/tasks/main.yml
@@ -27,6 +27,13 @@
     mode: "0755"
   loop: "{{ range(1, (node_count | int) + 1) | list }}"
 
+- name: Copy bitcoin.conf into data dirs
+  ansible.builtin.copy:
+    src: "{{ workdir }}/config/node{{ '%02d'|format(item) }}/bitcoin.conf"
+    dest: "{{ workdir }}/data/node{{ '%02d'|format(item) }}/bitcoin.conf"
+    remote_src: true
+  loop: "{{ range(1, (node_count | int) + 1) | list }}"
+
 - name: Ensure results dir exists
   ansible.builtin.file:
     path: "{{ workdir }}/results"

--- a/roles/bitcoin/templates/docker-compose.yml.j2
+++ b/roles/bitcoin/templates/docker-compose.yml.j2
@@ -13,7 +13,6 @@ services:
       bitcoind -regtest=1 -printtoconsole=1
       -conf=/home/bitcoin/.bitcoin/bitcoin.conf
     volumes:
-      - "{{ workdir }}/config/node{{ '%02d'|format(i) }}/bitcoin.conf:/home/bitcoin/.bitcoin/bitcoin.conf"
       - "{{ workdir }}/data/node{{ '%02d'|format(i) }}:/home/bitcoin/.bitcoin"
     networks: [ "{{ network_name }}" ]
 {% endfor %}


### PR DESCRIPTION
## Summary
- copy rendered `bitcoin.conf` into each node's data directory
- mount only per-node data directories in docker compose files

## Testing
- `ansible-playbook -i inventory.ini playbooks/02_deploy.yml --syntax-check`
- `docker compose -f docker-compose.yml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b95b315174832cb60ed66dd956ab67