### PR TITLE
Add macOS Docker install tasks and guard apt usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 Lokal lauffähige Experimente mit Crash/Omission-Faults, Recovery-Modi und Metriken (TPS, Confirmation Latency, Availability, Stale-Rate, TTR).
 Siehe `group_vars/all.yml` für Parameter; `playbooks/` für Orchestrierung; `files/` für Generator & Telemetrie; `analysis/` für Auswertung; `lrz/` für LRZ-Ready Hinweise.
+
+## macOS
+
+Für macOS wird eine vorhandene [Homebrew](https://brew.sh)-Installation vorausgesetzt. Nach der Installation kann es nötig sein, Docker Desktop manuell zu starten.

--- a/playbooks/01_bootstrap.yml
+++ b/playbooks/01_bootstrap.yml
@@ -7,6 +7,7 @@
         name: docker.io
         state: present
         update_cache: true
+      when: ansible_os_family == 'Debian'
 
     - name: Check if 'docker compose' is available
       ansible.builtin.shell: docker compose version
@@ -19,11 +20,26 @@
         name: docker-compose-v2
         state: present
         update_cache: true
-      when: compose_check.rc != 0
+      when:
+        - ansible_os_family == 'Debian'
+        - compose_check.rc != 0
       failed_when: false
+
+    - name: Ensure Docker is installed (macOS)
+      community.general.homebrew:
+        name: docker
+        state: present
+      when: ansible_os_family == 'Darwin'
+
+    - name: Ensure Docker Desktop is installed (macOS)
+      community.general.homebrew_cask:
+        name: docker
+        state: present
+      when: ansible_os_family == 'Darwin'
 
     - name: Add invoking user to docker group (idempotent)
       ansible.builtin.user:
         name: "{{ (ansible_env.SUDO_USER | default(ansible_user_id, true)) | default(ansible_env.USER) }}"
         groups: docker
         append: true
+      when: ansible_os_family == 'Debian'


### PR DESCRIPTION
## Summary
- limit Debian package installs to Debian/Ubuntu
- add Homebrew tasks to install Docker on macOS
- document macOS Homebrew requirement and Docker Desktop start

## Testing
- `ansible-playbook --syntax-check playbooks/01_bootstrap.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b963025e54832c9eebd6063428dc37