### PR TITLE
Fix bitcoin.conf copy permission by using become

### DIFF
--- a/roles/bitcoin/tasks/main.yml
+++ b/roles/bitcoin/tasks/main.yml
@@ -27,6 +27,14 @@
     mode: "0755"
   loop: "{{ range(1, (node_count | int) + 1) | list }}"
 
+- name: Copy bitcoin.conf into data dirs
+  become: true
+  ansible.builtin.copy:
+    src: "{{ workdir }}/config/node{{ '%02d'|format(item) }}/bitcoin.conf"
+    dest: "{{ workdir }}/data/node{{ '%02d'|format(item) }}/bitcoin.conf"
+    mode: "0644"
+  loop: "{{ range(1, (node_count | int) + 1) | list }}"
+
 - name: Ensure results dir exists
   ansible.builtin.file:
     path: "{{ workdir }}/results"


### PR DESCRIPTION
## Summary
- ensure bitcoin.conf files are copied into data directories with elevated privileges

## Testing
- `ansible-playbook -i inventory.ini playbooks/02_deploy.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_68b96842de00832c8298b504f27bc544